### PR TITLE
Fixed adding to cart quantities

### DIFF
--- a/main/serializers.py
+++ b/main/serializers.py
@@ -128,12 +128,17 @@ class AddToOrderSerializer(serializers.Serializer):
         quantities = validated_data['quantity']
         for index, item in enumerate(items):
             item = Item.objects.get(id=item)
+            quantity = quantities[index]
             order_item, created = OrderItem.objects.get_or_create(order=instance, item=item)
-            order_item.quantity = quantities[index]
-            if order_item.quantity == 0:
-                order_item.delete()
-            else:
+
+            if quantity > 0 and created:
+                order_item.quantity = quantity
                 order_item.save()
+            elif quantity > 0 and not created:
+                order_item.quantity += quantity
+                order_item.save()
+            else:
+                order_item.delete()
 
         instance.set_weight()
         instance.set_total_price()


### PR DESCRIPTION
Before, If the item was a new item the quantity count would be off. If it is an existing item it is just overriding the original quantity with the new one. Now, on creation of an item on an order it will set it to whatever the quantity is, if it is an existing item on an order it will increment it by that quantity.
